### PR TITLE
use service catalog if HEAT_URL not provided

### DIFF
--- a/hot/utils/catalog.py
+++ b/hot/utils/catalog.py
@@ -1,0 +1,44 @@
+""" service document retrieval and extraction """
+
+import json
+import requests
+
+from token import get_auth_document
+
+
+def get_service_document(auth_doc, service_name):
+
+    for service in auth_doc['access']['serviceCatalog']:
+        if service['name'] == service_name:
+            return service
+    else:
+        return None
+
+
+def get_default_region(auth_doc):
+
+    default_region = auth_doc['access']['user'].get('RAX-AUTH:defaultRegion')
+
+    if default_region:
+        return default_region
+    else:
+        return None
+
+
+def get_service_endpoint(region, service_name, endpoint, username,
+                         password=None, api_key=None):
+
+    auth_doc = get_auth_document(endpoint, username, password=password,
+                                 api_key=api_key)
+
+    service = get_service_document(auth_doc, service_name)
+
+    if not region:
+        region = get_default_region(auth_doc)
+
+    if service:
+        for endpoint in service.get('endpoints', []):
+            if endpoint.get('region', '').lower() == region.lower():
+                return endpoint.get('publicURL', None)
+    else:
+        return None

--- a/hot/utils/token.py
+++ b/hot/utils/token.py
@@ -4,7 +4,7 @@ import json
 import requests
 
 
-def get_token(endpoint, username, password=None, api_key=None):
+def get_auth_document(endpoint, username, password=None, api_key=None):
     if "/v2.0" not in endpoint:
         endpoint = endpoint + "/v2.0"
     if "/tokens" not in endpoint:
@@ -28,4 +28,12 @@ def get_token(endpoint, username, password=None, api_key=None):
 
     response.raise_for_status()
     results = response.json()
+
+    return results
+
+
+def get_token(endpoint, username, password=None, api_key=None):
+    results = get_auth_document(endpoint, username, password=password,
+                                api_key=api_key)
+
     return results['access']['token']['id']


### PR DESCRIPTION
Splitting token retrieval into two parts: get the auth document, and
return the token. Added a new module _catalog_ to retrieve and search the
service catalog, and logic to make sure if we don't have a `HEAT_URL`
environment variable, that we do have an `OS_REGION_NAME`. Set a 
default region (iad) if no `OS_REGION_NAME` is provided, and handle
invalid regions.
