### PR TITLE
Exception handling

### DIFF
--- a/hot/shell.py
+++ b/hot/shell.py
@@ -458,7 +458,7 @@ def launch_test_deployment(hc, template, overrides, test, keep_failed,
             signal.alarm(0)
     except Exception as exc:
         print exc
-        if "Script exited with code 1" not in exc:
+        if "Script exited with code 1" not in str(exc):
             print("Infrastructure failure. Skipping tests.")
         else:
             print("Automation scripts failed. Running tests anyway:")


### PR DESCRIPTION
Adding in logic to run tests before the stack is deleted. This opens us up to pull log files off the target system before it is deleted and place them in the circle artifacts directory. This should cut down on the number of manual stacks we have to create to debug issues.

@JasonBoyles 