### PR TITLE
Default artifacts list

### DIFF
--- a/hot/utils/test.py
+++ b/hot/utils/test.py
@@ -26,8 +26,9 @@ def get_artifacts(artifacts=False, envvar='CIRCLE_ARTIFACTS'):
     for artifact in artifacts:
         target = directory + "/%(host)s/%(path)s"
         try:
-            get(artifact, target)
-        except as exc:
+            with hide('running', 'stdout'):
+                get(artifact, target)
+        except:
             pass
 
 

--- a/hot/utils/test.py
+++ b/hot/utils/test.py
@@ -17,16 +17,17 @@ def get_artifacts(artifacts=False, envvar='CIRCLE_ARTIFACTS'):
         pass
     else:
         heat_logs = ['/root/cfn-userdata.log', '/root/heat-script.log']
+        cloudinit_logs = ['/var/log/cloud-init.log', '/var/log/cloud-init-output.log']
         code = "python -c 'from glob import glob; \
                     print glob(\"/tmp/heat_chef/*-*-*-*-*/*.log\")'"
         chef_logs = literal_eval(run(code))
-        artifacts = heat_logs + chef_logs
+        artifacts = heat_logs + chef_logs + cloudinit_logs
 
     for artifact in artifacts:
         target = directory + "/%(host)s/%(path)s"
         try:
             get(artifact, target)
-        except:
+        except as exc:
             pass
 
 


### PR DESCRIPTION
This adds two entries to the default log collection:
 * `/var/log/cloud-init.log`
 * `/var/log/cloud-init-output.log`

Also hides the exceptions produced when one of the default files doesn't exist.