### PR TITLE
Installing hot and testing inside a container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: python
 python:
   - "2.7"
 install:
-  - pip install -r requirements.txt --use-mirrors
+  - python setup.py install
   - pip install pep8
 script:
   - pep8 hot
+# The following line tells Travis CI to build in a container
+sudo: false


### PR DESCRIPTION
Updating the Travis tests to actually install hot prior to running pep8. This will ensure the application can properly install within a Python 2.7 environment.

The `sudo` line is to perform tests within a container. This is typically much faster than waiting on a VM build.

